### PR TITLE
Initializes LFortran language server with configuration options

### DIFF
--- a/client/src/extension.ts
+++ b/client/src/extension.ts
@@ -8,7 +8,7 @@
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *   http: // www.apache.org/licenses/LICENSE-2.0
+ *     http: // www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -25,10 +25,10 @@ import * as vscode from "vscode";
 import which from "which";
 
 import {
-  LanguageClient,
-  LanguageClientOptions,
-  ServerOptions,
-  State,
+    LanguageClient,
+    LanguageClientOptions,
+    ServerOptions,
+    State,
 } from "vscode-languageclient/node";
 
 let client: LanguageClient;
@@ -40,39 +40,41 @@ let logger: vscode.LogOutputChannel
  * Called when vscode first activates the extension
  */
 export async function activate(context: vscode.ExtensionContext) {
-  logger = vscode.window.createOutputChannel('LFortran Language Server', {
-    log: true
-  });
+    logger = vscode.window.createOutputChannel('LFortran Language Server', {
+        log: true
+    });
 
-  logger.info("Extension activated.");
-  await startLangServer();
+    logger.info("Extension activated.");
+    await startLangServer();
 }
 
 async function checkPathExistsAndIsExecutable(path: string): Promise<boolean> {
-  let pathExistsAndIsExecutable: boolean = false;
+    let pathExistsAndIsExecutable: boolean = false;
 
-  try {
-    const stats = await fs.promises.stat(path);
-    pathExistsAndIsExecutable = stats.isFile() && (stats.mode & 0o111) !== 0;
-  } catch (err: any) {
-    if (err.code !== 'ENOENT') {
-      throw err; // Other errors
+    try {
+        const stats = await fs.promises.stat(path);
+        pathExistsAndIsExecutable = stats.isFile() && (stats.mode & 0o111) !== 0;
+    } catch (err: any) {
+        if (err.code !== 'ENOENT') {
+            throw err; // Other errors
+        }
     }
-  }
 
-  return pathExistsAndIsExecutable;
+    return pathExistsAndIsExecutable;
 }
 
-async function getLFortranPath(): Promise<string | null | undefined> {
-  const compilerSettings =
-    vscode.workspace.getConfiguration("LFortranLanguageServer.compiler");
-  let lfortranPath = compilerSettings.get<string>("lfortranPath");
-  if (lfortranPath === "lfortran"
-    || !(await checkPathExistsAndIsExecutable(lfortranPath))) {
-    lfortranPath = await which("lfortran", { nothrow: true });
-  }
-  logger.info(`lfortranPath = ${lfortranPath}`);
-  return lfortranPath;
+async function getConfig(): Promise<vscode.WorkspaceConfiguration> {
+    return vscode.workspace.getConfiguration("LFortranLanguageServer");
+}
+
+async function getLFortranPath(config: vscode.WorkspaceConfiguration): Promise<string | null | undefined> {
+    let lfortranPath = config.get<string>("compiler.lfortranPath");
+    if (lfortranPath === "lfortran"
+        || !(await checkPathExistsAndIsExecutable(lfortranPath))) {
+        lfortranPath = await which("lfortran", { nothrow: true });
+    }
+    logger.info(`lfortranPath = ${lfortranPath}`);
+    return lfortranPath;
 }
 
 /**
@@ -84,81 +86,110 @@ async function getLFortranPath(): Promise<string | null | undefined> {
  */
 async function startLangServer() {
 
-  // Don't interfere if we are already in the process of launching the server.
-  if (clientStarting) {
-    logger.info("clientStarting, returning ...");
-    return;
-  }
-
-  clientStarting = true;
-  if (client) {
-    await stopLangServer();
-  }
-
-  const lfortranPath = await getLFortranPath();
-  if (!lfortranPath) {
-    logger.warn("lfortran command not found.");
-    clientStarting = false;
-    return;
-  }
-
-  const serverOptions: ServerOptions = {
-    command: lfortranPath,
-    args: [
-      "server",
-    ],
-    options: {
-      env: process.env,
-    },
-  };
-
-  const clientOptions: LanguageClientOptions = {
-    documentSelector: [
-      {
-        scheme: "file",
-        language: "fortran"
-      },
-    ],
-    outputChannel: logger,
-    connectionOptions: {
-      maxRestartCount: 0 // don't restart on server failure.
-    },
-  };
-
-  client = new LanguageClient(
-    "LFortranLanguageServer",
-    "LFortran Language Server",
-    serverOptions,
-    clientOptions);
-
-  const promises = [client.start()]
-
-  const results = await Promise.allSettled(promises)
-  clientStarting = false
-
-  for (const result of results) {
-    if (result.status === "rejected") {
-      logger.error(`There was a error starting the server: ${result.reason}`)
+    // Don't interfere if we are already in the process of launching the server.
+    if (clientStarting) {
+        logger.info("clientStarting, returning ...");
+        return;
     }
-  }
+
+    clientStarting = true;
+    if (client) {
+        await stopLangServer();
+    }
+
+    const config = await getConfig();
+    const lfortranPath = await getLFortranPath(config);
+    if (!lfortranPath) {
+        logger.warn("lfortran command not found.");
+        clientStarting = false;
+        return;
+    }
+
+    const prettyPrint: boolean = config.get<boolean>("log.prettyPrint");
+    const indentSize: number = config.get<number>("log.indentSize");
+
+    const serverArgs: string[] = [
+        "server",
+        "--open-issue-reporter-on-error", config.get<boolean>("openIssueReporterOnError").toString(),
+        "--max-number-of-problems", config.get<number>("maxNumberOfProblems").toString(10),
+        "--trace-server", config.get<string>("trace.server"),
+        // "--compiler-path", config.get<string>("compiler.path"),
+        "--compiler-path", lfortranPath,
+        "--log-path", config.get<string>("log.path"),
+        "--log-level", config.get<string>("log.level"),
+        "--log-pretty-print", prettyPrint.toString(),
+        "--log-indent-size", indentSize.toString(10),
+    ];
+
+    const compilerFlags = config.get<string[]>("compiler.flags");
+    if (compilerFlags.length > 0) {
+        serverArgs.push("--")
+        for (const compilerFlag of compilerFlags) {
+            serverArgs.push(compilerFlag)
+        }
+    }
+
+    const serverOptions: ServerOptions = {
+        command: lfortranPath,
+        args: serverArgs,
+        options: {
+            env: process.env,
+        },
+    };
+
+    if (prettyPrint) {
+        logger.debug(`Executing lfortran: ${JSON.stringify(serverOptions, undefined, indentSize)}`)
+    } else {
+        logger.debug(`Executing lfortran: ${JSON.stringify(serverOptions)}`)
+    }
+
+    const clientOptions: LanguageClientOptions = {
+        documentSelector: [
+            {
+                scheme: "file",
+                language: "fortran"
+            },
+        ],
+        outputChannel: logger,
+        connectionOptions: {
+            maxRestartCount: Number.MAX_SAFE_INTEGER
+        },
+    };
+
+    client = new LanguageClient(
+        "LFortranLanguageServer",
+        "LFortran Language Server",
+        serverOptions,
+        clientOptions);
+
+    const promises = [client.start()]
+
+    const results = await Promise.allSettled(promises)
+    clientStarting = false
+
+    for (const result of results) {
+        if (result.status === "rejected") {
+            logger.error(`There was a error starting the server: ${result.reason}`)
+        }
+    }
 }
 
 export function deactivate(): Thenable<void> {
-  return stopLangServer();
+    return stopLangServer();
 }
 
 async function stopLangServer(): Promise<void> {
-  logger.info("Stopping lang server ...");
-  if (!client) {
-    logger.info("No client to stop, returning...");
-    return
-  }
+    logger.info("Stopping lang server ...");
+    if (!client) {
+        logger.info("No client to stop, returning...");
+        return
+    }
 
-  if (client.state === State.Running) {
-    await client.stop();
-    logger.info("Client stopped ...");
-  }
+    if (client.state === State.Running) {
+        await client.stop();
+        logger.info("Client stopped ...");
+    }
 
-  client.dispose()
-  client = undefined
+    client.dispose()
+    client = undefined
 }

--- a/esbuild.js
+++ b/esbuild.js
@@ -3,7 +3,7 @@ import * as esbuild from 'esbuild';
 const watch = process.argv.includes('--watch');
 
 let production = process.argv.includes('--production');
-if (process.env.FORTLS_LFORTRAN_MODE === "debug") {
+if (process.env.LFORTRAN_LSP_MODE === "debug") {
   production = false;
 }
 

--- a/package.json
+++ b/package.json
@@ -1,152 +1,146 @@
 {
-  "name": "lfortran-lsp",
-  "description": "LFortran language server protocol (LSP).",
-  "author": "LCompilers",
-  "license": "MIT",
-  "version": "0.0.1",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/lfortran/lfortran-lsp"
-  },
-  "publisher": "LCompilers",
-  "categories": [],
-  "keywords": [
-    "multi-root ready"
-  ],
-  "engines": {
-    "vscode": "^1.63.0"
-  },
-  "activationEvents": [
-    "onLanguage:fortran"
-  ],
-  "main": "./out/extension.js",
-  "contributes": {
-    "languages": [
-      {
-        "id": "fortran",
-        "aliases": [
-          "lfortran"
-        ],
-        "extensions": [
-          ".f",
-          ".for",
-          ".f90",
-          ".f95",
-          ".f03"
-        ]
-      }
+    "name": "lfortran-lsp",
+    "description": "LFortran language server protocol (LSP).",
+    "author": "LCompilers",
+    "license": "MIT",
+    "version": "0.0.1",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/lfortran/lfortran-lsp"
+    },
+    "publisher": "LCompilers",
+    "categories": [],
+    "keywords": [
+        "multi-root ready"
     ],
-    "configuration": {
-      "type": "object",
-      "title": "LFortran Language Server",
-      "properties": {
-        "LFortranLanguageServer.openIssueReporterOnError": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": false,
-          "description": "Open the issue reporter to submit a generated bug report when an internal error is detected."
-        },
-        "LFortranLanguageServer.maxNumberOfProblems": {
-          "scope": "resource",
-          "type": "number",
-          "default": 100,
-          "description": "Controls the maximum number of problems produced by the server."
-        },
-        "LFortranLanguageServer.trace.server": {
-          "scope": "window",
-          "type": "string",
-          "enum": [
-            "off",
-            "messages",
-            "verbose"
-          ],
-          "default": "off",
-          "description": "Traces the communication between VS Code and the language server."
-        },
-        "LFortranLanguageServer.compiler.lfortranPath": {
-          "scope": "resource",
-          "type": "string",
-          "default": "lfortran",
-          "description": "The path to the LFortran compiler executable."
-        },
-        "LFortranLanguageServer.compiler.flags": {
-          "scope": "resource",
-          "type": "array",
-          "item": {
-            "type": "string"
-          },
-          "default": [],
-          "description": "Additional flags to pass to the LFortran compiler."
-        },
-        "LFortranLanguageServer.log.level": {
-          "scope": "resource",
-          "type": "string",
-          "enum": [
-            "off",
-            "fatal",
-            "error",
-            "warn",
-            "info",
-            "debug",
-            "trace",
-            "all"
-          ],
-          "default": "info",
-          "description": "Lowest level of logs to include in the extension's console output."
-        },
-        "LFortranLanguageServer.log.benchmark": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": false,
-          "description": "Whether to benchmark event handlers and related operations."
-        },
-        "LFortranLanguageServer.log.filter": {
-          "scope": "resource",
-          "type": "string",
-          "default": "",
-          "description": "Regular expression for filtering log messages."
-        },
-        "LFortranLanguageServer.log.prettyPrint": {
-          "scope": "resource",
-          "type": "boolean",
-          "default": true,
-          "description": "Whether to pretty-print JSON objects and arrays."
-        },
-        "LFortranLanguageServer.log.indentSize": {
-          "scope": "resource",
-          "type": "number",
-          "default": 2,
-          "description": "Number of spaces to indent the pretty-printed JSON."
+    "engines": {
+        "vscode": "^1.63.0"
+    },
+    "activationEvents": [
+        "onLanguage:fortran"
+    ],
+    "main": "./out/extension.js",
+    "contributes": {
+        "languages": [
+            {
+                "id": "fortran",
+                "aliases": [
+                    "lfortran"
+                ],
+                "extensions": [
+                    ".f",
+                    ".for",
+                    ".f90",
+                    ".f95",
+                    ".f03"
+                ]
+            }
+        ],
+        "configuration": {
+            "type": "object",
+            "title": "LFortran Language Server",
+            "properties": {
+                "LFortranLanguageServer.openIssueReporterOnError": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Open a bug report if an internal error occurs."
+                },
+                "LFortranLanguageServer.maxNumberOfProblems": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 100,
+                    "description": "Maximum number of errors and warnings to report."
+                },
+                "LFortranLanguageServer.trace.server": {
+                    "scope": "window",
+                    "type": "string",
+                    "enum": [
+                        "off",
+                        "messages",
+                        "verbose"
+                    ],
+                    "default": "off",
+                    "description": "Traces the communication between the language client and server."
+                },
+                "LFortranLanguageServer.compiler.path": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "lfortran",
+                    "description": "Path to the LFortran compiler executable."
+                },
+                "LFortranLanguageServer.compiler.flags": {
+                    "scope": "resource",
+                    "type": "array",
+                    "item": {
+                        "type": "string"
+                    },
+                    "default": [],
+                    "description": "Additional flags to pass to the LFortran compiler."
+                },
+                "LFortranLanguageServer.log.path": {
+                    "scope": "window",
+                    "type": "string",
+                    "default": "lfortran-language-server.log",
+                    "description": "Where the log file should be written."
+                },
+                "LFortranLanguageServer.log.level": {
+                    "scope": "window",
+                    "type": "string",
+                    "enum": [
+                        "off",
+                        "fatal",
+                        "error",
+                        "warn",
+                        "info",
+                        "debug",
+                        "trace",
+                        "all"
+                    ],
+                    "default": "info",
+                    "description": "Lowest level of logs to include in the extension's console output."
+                },
+                "LFortranLanguageServer.log.prettyPrint": {
+                    "scope": "window",
+                    "type": "boolean",
+                    "default": true,
+                    "description": "Whether to pretty-print JSON objects and arrays."
+                },
+                "LFortranLanguageServer.log.indentSize": {
+                    "scope": "window",
+                    "type": "number",
+                    "default": 4,
+                    "description": "Number of spaces to indent the pretty-printed JSON."
+                }
+            }
         }
-      }
+    },
+    "scripts": {
+        "postinstall": "cd client && npm install && cd ..",
+        "compile": "npm run check-types && node esbuild.js",
+        "check-types": "tsc --noEmit",
+        "watch": "npm-run-all -p watch:*",
+        "watch:esbuild": "node esbuild.js --watch",
+        "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
+        "vscode:prepublish": "npm run package",
+        "lint": "eslint ./client/src",
+        "package": "npm run check-types && node esbuild.js --production"
+    },
+    "devDependencies": {
+        "@aws-sdk/client-s3": "^3.699.0",
+        "@eslint/js": "^9.15.0",
+        "@types/node": "^22.9.1",
+        "@typescript-eslint/eslint-plugin": "^8.15.0",
+        "@typescript-eslint/parser": "^8.15.0",
+        "@vscode/vsce": "^3.2.1",
+        "esbuild": "^0.24.0",
+        "eslint": "^9.15.0",
+        "globals": "^15.12.0",
+        "tsx": "^4.19.2",
+        "typescript": "^5.6.3",
+        "typescript-eslint": "^8.15.0"
+    },
+    "dependencies": {
+        "source-map-support": "^0.5.21"
     }
-  },
-  "scripts": {
-    "postinstall": "cd client && npm install && cd ..",
-    "compile": "npm run check-types && node esbuild.js",
-    "check-types": "tsc --noEmit",
-    "watch": "npm-run-all -p watch:*",
-    "watch:esbuild": "node esbuild.js --watch",
-    "watch:tsc": "tsc --noEmit --watch --project tsconfig.json",
-    "vscode:prepublish": "npm run package",
-    "lint": "eslint ./client/src",
-    "package": "npm run check-types && node esbuild.js --production"
-  },
-  "devDependencies": {
-    "@aws-sdk/client-s3": "^3.699.0",
-    "@eslint/js": "^9.15.0",
-    "@types/node": "^22.9.1",
-    "@typescript-eslint/eslint-plugin": "^8.15.0",
-    "@typescript-eslint/parser": "^8.15.0",
-    "@vscode/vsce": "^3.2.1",
-    "esbuild": "^0.24.0",
-    "eslint": "^9.15.0",
-    "globals": "^15.12.0",
-    "tsx": "^4.19.2",
-    "typescript": "^5.6.3",
-    "typescript-eslint": "^8.15.0"
-  },
-  "dependencies": {
-    "source-map-support": "^0.5.21"
-  }
 }


### PR DESCRIPTION
Changes:
* Adds config option for log path
* Removes config options for benchmarking and filtering logs since they are no longer needed
* Passes config options to lfortran when the server is initialized

Depends on: https://github.com/dylon/lfortran/pull/1